### PR TITLE
add separator when not given

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -231,6 +231,9 @@ $image-organizer/tests/python -m pytest tests
     * Improve Tool Help
     * Improve Readme
 
+* 4.0
+    * Fix destination parameter when there is no separator
+
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->

--- a/reorganize.py
+++ b/reorganize.py
@@ -81,8 +81,11 @@ def get_arguments() -> Tuple[bool, str, str, Tuple[Union[str, Any], ...], bool]:
             logging.warning('[-] The "source" parameter is mandatory')
             sys.exit()
 
-    if args.destination:
-        if os.path.isdir(args.destination):
+    app_destination = args.destination
+    if app_destination:
+        if not app_destination.endswith(os.path.sep):
+            app_destination = app_destination + os.path.sep
+        if os.path.isdir(app_destination):
             logging.warning("[-] The destination path specified already exist")
             do_you_want_to_continue()
     else:
@@ -98,7 +101,7 @@ def get_arguments() -> Tuple[bool, str, str, Tuple[Union[str, Any], ...], bool]:
     if args.loglevel:
         app_debug = True
 
-    return is_mtp, app_source, args.destination, extensions, app_debug
+    return is_mtp, app_source, app_destination, extensions, app_debug
 
 
 def init_logger(level):
@@ -122,7 +125,7 @@ if __name__ == '__main__':
 
     try:
         init_logger(debug)
-        logging.debug("[+] Parameters: source= %s, destination= %s, extennsions= %s, debug= %s", source, destination,
+        logging.debug("[+] Parameters: source= %s, destination= %s, extensions= %s, debug= %s", source, destination,
                       extensions, debug)
         image_organizer = get_file_organizer(is_mtp, source, destination, extensions)
         logging.debug("[+] Starting")

--- a/reorganize.py
+++ b/reorganize.py
@@ -47,8 +47,6 @@ def get_arguments() -> Tuple[bool, str, str, Tuple[Union[str, Any], ...], bool]:
     is_mtp: bool = False
     app_source = args.source
     if app_source:
-        if not app_source.endswith(os.path.sep):
-            app_source = args.source + os.path.sep
         if not os.path.isdir(app_source):
             logging.warning('[-] The source path specified does not exist')
             sys.exit()
@@ -83,8 +81,6 @@ def get_arguments() -> Tuple[bool, str, str, Tuple[Union[str, Any], ...], bool]:
 
     app_destination = args.destination
     if app_destination:
-        if not app_destination.endswith(os.path.sep):
-            app_destination = app_destination + os.path.sep
         if os.path.isdir(app_destination):
             logging.warning("[-] The destination path specified already exist")
             do_you_want_to_continue()

--- a/src/organizer.py
+++ b/src/organizer.py
@@ -20,6 +20,31 @@ class FileOrganizer:
     def get_file_processor():
         return FileProcessor()
 
+    def start(self):
+        if self.source and self.destination:
+            self.validate_data_input()
+            logging.info("[+] Start Processing")
+            files = self.get_files(self.source, self.extensions)
+            all_files = files[0]
+            list_of_files_to_be_processed = files[1]
+            missing = files[2]
+            if list_of_files_to_be_processed:
+                self.reporting_summary(all_files, list_of_files_to_be_processed, missing)
+                do_you_want_to_continue()
+                self.file_process.process(list_of_files_to_be_processed, self.destination)
+            else:
+                logging.info("[-] No files found that matches the types")
+
+    def validate_data_input(self):
+        # Validates that the source and destination folder ends up with a os.path.separator
+        # if not we will add a separator
+
+        if not self.source.endswith(os.path.sep):
+            self.source = self.source + os.path.sep
+
+        if not self.destination.endswith(os.path.sep):
+            self.destination = self.destination + os.path.sep
+
     def get_files(self, source: str, extensions: Tuple[str]) -> List[List[str]]:
         all_files, processed_files = self._filter_files(source, extensions)
         missing_files = [x for x in all_files if x not in processed_files]
@@ -46,20 +71,6 @@ class FileOrganizer:
             if extension not in unique_extensions:
                 unique_extensions.add(extension)
         return unique_extensions
-
-    def start(self):
-        if self.source and self.destination:
-            logging.info("[+] Start Processing")
-            files = self.get_files(self.source, self.extensions)
-            all_files = files[0]
-            list_of_files_to_be_processed = files[1]
-            missing = files[2]
-            if list_of_files_to_be_processed:
-                self.reporting_summary(all_files, list_of_files_to_be_processed, missing)
-                do_you_want_to_continue()
-                self.file_process.process(list_of_files_to_be_processed, self.destination)
-            else:
-                logging.info("[-] No files found that matches the types")
 
     def reporting_summary(self, all_files, list_of_processed, missing):
         logging.info(" ")


### PR DESCRIPTION
# Pull Request - File Organizer

## Overview
When the destination parameter doesn't end with the separator we need to add it.

## Checklist:
Go through these points to ensure the PR fulfills expectations.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
